### PR TITLE
removed build.TAGS check

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         
         minSdk 29
         targetSdk 33
-        versionCode 4
-        versionName "1.1.2"
+        versionCode 5
+        versionName "1.1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 3,
-      "versionName": "1.1.1",
+      "versionCode": 5,
+      "versionName": "1.1.3",
       "outputFile": "app-release.apk"
     }
   ],

--- a/app/src/main/java/org/privacymatters/safespace/lib/RootCheck.java
+++ b/app/src/main/java/org/privacymatters/safespace/lib/RootCheck.java
@@ -7,12 +7,6 @@ import java.io.File;
 public class RootCheck {
     public static boolean isRooted() {
 
-        // get from build info
-        String buildTags = android.os.Build.TAGS;
-        if (buildTags != null && buildTags.contains("test-keys")) {
-            return true;
-        }
-
         // check if /system/app/Superuser.apk is present
         try {
             File file = new File("/system/app/Superuser.apk");

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,1 @@
+Removed check for "test-keys" Tag as non-rooted devices with custom rom were falsely flagged as rooted


### PR DESCRIPTION
Removed check for "test-keys" Tag as non-rooted devices with custom rom were falsely flagged as rooted